### PR TITLE
PHP74 compatibility

### DIFF
--- a/src/ImageStorage/S3/S3.php
+++ b/src/ImageStorage/S3/S3.php
@@ -2017,7 +2017,7 @@ final class S3Request
 			elseif ($header == 'Content-Type')
 				$this->response->headers['type'] = $value;
 			elseif ($header == 'ETag')
-				$this->response->headers['hash'] = $value{0} == '"' ? substr($value, 1, -1) : $value;
+				$this->response->headers['hash'] = $value[0] == '"' ? substr($value, 1, -1) : $value;
 			elseif (preg_match('/^x-amz-meta-.*$/', $header))
 				$this->response->headers[$header] = $value;
 		}


### PR DESCRIPTION
# Reason
> E_DEPRECATED: Array and string offset access syntax with curly braces is deprecated {"code":8192,"message":"Array and string offset access syntax with curly braces is deprecated","file":"/var/www/html/vendor/lbarulski/image-storage/src/ImageStorage/S3/S3.php","line":2020}